### PR TITLE
Use env vars for SMTP credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration for ATIEMPO
+# Rename this file to .env and provide real values.
+
+EMAIL_USER=your_email@example.com
+EMAIL_PASS=your_app_password

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import logging
 import firebase_admin
 import smtplib
 from email.message import EmailMessage
+import os
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -67,7 +68,7 @@ Equipo ATIEMPO
 
     try:
         with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
-            smtp.login("info.elebi@gmail.com", "zftlzvphvwopxnob") # <<< IMPORTANT: Replace with your actual App Password
+            smtp.login(os.environ.get("EMAIL_USER"), os.environ.get("EMAIL_PASS"))
             smtp.send_message(msg)
             logging.info(f"✅ Email sent to {to_email}")
     except Exception as e:


### PR DESCRIPTION
## Summary
- secure SMTP credentials by reading from environment variables
- provide `.env.example` with placeholders for credentials

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68508acbbf90832fb22beeb51cc7412b